### PR TITLE
Fix CatLink integration runtime issues

### DIFF
--- a/custom_components/catlink/entitites/catlink.py
+++ b/custom_components/catlink/entitites/catlink.py
@@ -80,7 +80,7 @@ class CatlinkEntity(CoordinatorEntity):
         self._attr_icon = self._option.get("icon")
         self._attr_device_class = self._option.get("class")
         self._attr_unit_of_measurement = self._option.get("unit")
-        self._attr_state_class = option.get("state_class")
+        self._attr_state_class = self._option.get("state_class")
         
         # Build device information
         device_info = {

--- a/custom_components/catlink/helpers.py
+++ b/custom_components/catlink/helpers.py
@@ -1,7 +1,6 @@
 """Helper functions for the CatLink integration."""
 
 from datetime import timedelta
-import re
 from typing import TYPE_CHECKING
 
 from homeassistant.core import HomeAssistant
@@ -16,27 +15,59 @@ class Helper:
     """Helper class for the CatLink integration."""
 
     @classmethod
-    def calculate_update_interval(cls, update_interval_str: str) -> timedelta:
-        """Calculate the update interval as a timedelta object based on the given update_interval_str.
+    def calculate_update_interval(cls, update_interval_str) -> timedelta:
+        """Calculate a :class:`timedelta` for the polling interval.
+
+        The configuration schema accepts either a ``timedelta`` object (from
+        YAML validation) or a string in ``HH:MM:SS`` format (from config
+        entries).  The previous implementation attempted to run a regular
+        expression against the value without checking its type which raises a
+        ``TypeError`` when a ``timedelta`` is supplied.  This prevented YAML
+        configured users from setting a custom scan interval and effectively
+        broke the integration for them.
 
         Args:
-            update_interval_str (str): The update interval string in the format "HH:MM:SS".
+            update_interval_str: ``timedelta`` or ``HH:MM:SS`` string.
 
         Returns:
             timedelta: The update interval as a timedelta object.
-
         """
 
-        return (
-            timedelta(minutes=10)
-            if not update_interval_str
-            or not re.match(r"^\d{2}:\d{2}:\d{2}$", update_interval_str)
-            else timedelta(
-                hours=int(update_interval_str[:2]),
-                minutes=int(update_interval_str[3:5]),
-                seconds=int(update_interval_str[6:8]),
-            )
-        )
+        if isinstance(update_interval_str, timedelta):
+            return update_interval_str
+
+        if isinstance(update_interval_str, (int, float)):
+            return timedelta(seconds=int(update_interval_str))
+
+        if isinstance(update_interval_str, str):
+            candidate = update_interval_str.strip()
+
+            if not candidate:
+                return timedelta(minutes=10)
+
+            if candidate.isdigit():
+                return timedelta(seconds=int(candidate))
+
+            try:
+                hours, minutes, seconds = candidate.split(":")
+            except ValueError:
+                pass
+            else:
+                try:
+                    return timedelta(
+                        hours=int(hours),
+                        minutes=int(minutes),
+                        seconds=int(seconds),
+                    )
+                except ValueError:
+                    pass
+
+            try:
+                return timedelta(seconds=int(float(candidate)))
+            except ValueError:
+                pass
+
+        return timedelta(minutes=10)
 
     @classmethod
     async def async_setup_accounts(cls, hass: HomeAssistant, domain) -> None:

--- a/custom_components/catlink/modules/account.py
+++ b/custom_components/catlink/modules/account.py
@@ -55,8 +55,12 @@ class Account:
     def password(self) -> str:
         """Return the password of the account."""
         pwd = self._config.get(CONF_PASSWORD)
+        if not isinstance(pwd, str):
+            return ""
+
         if len(pwd) <= 16:
-            pwd = self.encrypt_password(pwd)
+            return self.encrypt_password(pwd)
+
         return pwd
 
     @property


### PR DESCRIPTION
## Summary
- prevent CatLink entity initialisation from crashing when a state class is defined
- accept YAML `timedelta` values and flexible strings when computing update intervals
- guard password handling against missing/invalid values before encrypting

## Testing
- python -m compileall custom_components/catlink

------
https://chatgpt.com/codex/tasks/task_e_68cd9d3226b4832b817a20070532d953